### PR TITLE
fix pyodide settings

### DIFF
--- a/src/components/webworker.mjs
+++ b/src/components/webworker.mjs
@@ -1,6 +1,8 @@
 import { loadPyodide } from "https://cdn.jsdelivr.net/pyodide/v0.27.6/full/pyodide.mjs";
 
-let pyodideReadyPromise = loadPyodide().then((pyodide) => {
+let pyodideReadyPromise = loadPyodide({
+  indexURL: "https://cdn.jsdelivr.net/pyodide/v0.27.6/full/",
+}).then((pyodide) => {
   self.postMessage({ ready: true });
   return pyodide;
 });
@@ -24,10 +26,10 @@ self.onmessage = async (event) => {
   await pyodide.loadPackagesFromImports(python);
   await pyodide.loadPackage("micropip");
   const micropip = pyodide.pyimport("micropip");
-  await micropip.install('plotly.express');
+  await micropip.install("plotly.express");
   await micropip.install("ssl");
-  await micropip.install('geopy');
-  await micropip.install('folium');
+  await micropip.install("geopy");
+  await micropip.install("folium");
 
   const dict = pyodide.globals.get("dict");
   const globals = dict(Object.entries(context));

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,8 +5,9 @@ export default defineConfig({
   plugins: [react()],
   build: {
     rollupOptions: {
+      // Prevent bundling of CDN imports
+      external: [/^https:\/\/cdn\.jsdelivr\.net\/pyodide\/.*/],
       output: {
-        // Preserve WebR WASM files without hash for proper loading
         assetFileNames: (assetInfo) => {
           if (assetInfo.name && assetInfo.name.endsWith(".wasm")) {
             return "[name][extname]";
@@ -16,8 +17,14 @@ export default defineConfig({
       },
     },
   },
+  // Apply the same external rule to worker builds
+  worker: {
+    format: "es",
+    rollupOptions: {
+      external: [/^https:\/\/cdn\.jsdelivr\.net\/pyodide\/.*/],
+    },
+  },
   server: {
-    // Enable COOP/COEP headers for local development
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",
       "Cross-Origin-Opener-Policy": "same-origin",
@@ -25,14 +32,12 @@ export default defineConfig({
     host: true,
   },
   preview: {
-    // Enable COOP/COEP headers for preview mode
     headers: {
       "Cross-Origin-Embedder-Policy": "require-corp",
       "Cross-Origin-Opener-Policy": "same-origin",
     },
   },
   optimizeDeps: {
-    // Exclude WebR and pyodide packages from dependency optimization
     exclude: ["@r-wasm/webr", "webr", "pyodide"],
   },
 });


### PR DESCRIPTION

**Pyodide Integration Improvements:**
* Updated the `loadPyodide` call in `webworker.mjs` to explicitly set the `indexURL`, ensuring Pyodide assets are loaded from the correct CDN path.
* Standardized string quotes for `micropip.install` package names in `webworker.mjs` for consistency and readability.

**Build Configuration Enhancements:**
* Modified `vite.config.js` to mark all Pyodide CDN imports as external, preventing them from being bundled with the app.
* Applied the external rule to both main and worker builds in Vite, ensuring proper handling of Pyodide dependencies in web workers.